### PR TITLE
Bugfixes from running test programs

### DIFF
--- a/src/main/java/com/computer/nand2tetris/compiler/JackAnalyzer.java
+++ b/src/main/java/com/computer/nand2tetris/compiler/JackAnalyzer.java
@@ -2,9 +2,10 @@ package com.computer.nand2tetris.compiler;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
-import com.computer.nand2tetris.compiler.io.ParsedXmlWriter;
 import com.computer.nand2tetris.compiler.io.IOPaths;
 import com.computer.nand2tetris.compiler.io.IOPathsCreator;
+import com.computer.nand2tetris.compiler.io.ParsedXmlWriter;
+import com.computer.nand2tetris.compiler.io.TokensWriter;
 import com.computer.nand2tetris.compiler.parser.JackParser;
 import com.computer.nand2tetris.compiler.tokenizer.JackTokenizer;
 import com.google.common.base.Optional;
@@ -21,10 +22,36 @@ final class JackAnalyzer {
 
   private final JackTokenizer tokenizer;
   private final JackParser parser;
+  private final TokensWriter tokensWriter;
 
-  JackAnalyzer(JackTokenizer tokenizer, JackParser parser) {
+  JackAnalyzer(JackTokenizer tokenizer, JackParser parser, TokensWriter tokensWriter) {
     this.tokenizer = tokenizer;
     this.parser = parser;
+    this.tokensWriter = tokensWriter;
+  }
+
+  private static Stream<String> getInputPaths(ImmutableList<IOPaths> ioPaths) {
+    return ioPaths.stream().map(IOPaths::inputFilePath);
+  }
+
+  private static BufferedReader createReader(String filePath) {
+    try {
+      return new BufferedReader(new FileReader(filePath));
+    } catch (FileNotFoundException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static BufferedWriter createWriter(String filePath) throws IOException {
+    return new BufferedWriter(new FileWriter(filePath));
+  }
+
+  public static void main(String[] args) throws IOException {
+    ImmutableList<IOPaths> ioPaths = IOPathsCreator.createPaths(args);
+    //System.err.println(ioPaths);
+    JackAnalyzer analyzer = new JackAnalyzer(new JackTokenizer(), new JackParser(),
+        new TokensWriter());
+    analyzer.analyze(ioPaths);
   }
 
   private void analyze(ImmutableList<IOPaths> ioPaths) throws IOException {
@@ -57,41 +84,20 @@ final class JackAnalyzer {
     return inputPaths.map(JackAnalyzer::createReader).collect(toImmutableList());
   }
 
-  private static Stream<String> getInputPaths(ImmutableList<IOPaths> ioPaths) {
-    return ioPaths.stream().map(IOPaths::inputFilePath);
-  }
-
   private void compile(IOPaths ioPaths, Context context) {
     try {
       BufferedReader reader = createReader(ioPaths.inputFilePath());
-      BufferedWriter writer = createWriter(ioPaths.parserOutputPath());
+      BufferedWriter parserOutputWriter = createWriter(ioPaths.parserOutputPath());
       ImmutableList<JackToken> tokens = tokenizer.tokenize(reader);
+      tokensWriter.writeTokens(tokens, createWriter(ioPaths.tokenizerOutputPath()));
       parser.parse(
           tokens,
           Optional.of(context),
-          new ParsedXmlWriter(writer));
+          new ParsedXmlWriter(parserOutputWriter, JackParser.NON_TERMINALS_TO_PARSE));
       reader.close();
-      writer.close();
+      parserOutputWriter.close();
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
-  }
-
-  private static BufferedReader createReader(String filePath) {
-    try {
-      return new BufferedReader(new FileReader(filePath));
-    } catch (FileNotFoundException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  private static BufferedWriter createWriter(String filePath) throws IOException {
-    return new BufferedWriter(new FileWriter(filePath));
-  }
-
-  public static void main(String[] args) throws IOException {
-    ImmutableList<IOPaths> ioPaths = IOPathsCreator.createPaths(args);
-    JackAnalyzer analyzer = new JackAnalyzer(new JackTokenizer(), new JackParser());
-    analyzer.analyze(ioPaths);
   }
 }

--- a/src/main/java/com/computer/nand2tetris/compiler/JackToken.java
+++ b/src/main/java/com/computer/nand2tetris/compiler/JackToken.java
@@ -1,5 +1,6 @@
 package com.computer.nand2tetris.compiler;
 
+import com.computer.nand2tetris.compiler.io.CamelCaseConverter;
 import com.google.auto.value.AutoValue;
 
 @AutoValue
@@ -10,7 +11,7 @@ public abstract class JackToken {
 
     @Override
     public String toString() {
-      return name().toLowerCase();
+      return CamelCaseConverter.convert(name().toLowerCase());
     }
   }
 

--- a/src/main/java/com/computer/nand2tetris/compiler/LookAheadStream.java
+++ b/src/main/java/com/computer/nand2tetris/compiler/LookAheadStream.java
@@ -21,7 +21,7 @@ public final class LookAheadStream<T> {
   public Optional<T> extract() {
     Optional<T> extractedLookAhead = peek();
     resetStateFromList(restItems);
-    System.err.println(restItems);
+    //System.err.println(restItems);
     return extractedLookAhead;
   }
 

--- a/src/main/java/com/computer/nand2tetris/compiler/StackBasedJackElementVisitor.java
+++ b/src/main/java/com/computer/nand2tetris/compiler/StackBasedJackElementVisitor.java
@@ -13,7 +13,7 @@ public abstract class StackBasedJackElementVisitor implements JackElementVisitor
   @Override
   public final void beginNonTerminalVisit(String nonTerminalText) {
     nonTerminalsBeingVisited.push(nonTerminalText);
-    System.err.println("pushed " + nonTerminalText + ", stack: " + nonTerminalsBeingVisited);
+    //System.err.println("pushed " + nonTerminalText + ", stack: " + nonTerminalsBeingVisited);
     beginVisitForNonTerminal(nonTerminalText);
   }
 
@@ -21,7 +21,7 @@ public abstract class StackBasedJackElementVisitor implements JackElementVisitor
   public final void endNonTerminalVisit() {
     Preconditions.checkArgument(!nonTerminalsBeingVisited.isEmpty(),
         "No non terminals being visited. Can not end visit.");
-    System.err.println("popping " + nonTerminalsBeingVisited.peek() + ", stack: " + nonTerminalsBeingVisited);
+    //System.err.println("popping " + nonTerminalsBeingVisited.peek() + ", stack: " + nonTerminalsBeingVisited);
     endVisitForNonTerminal(nonTerminalsBeingVisited.pop());
   }
 }

--- a/src/main/java/com/computer/nand2tetris/compiler/io/CamelCaseConverter.java
+++ b/src/main/java/com/computer/nand2tetris/compiler/io/CamelCaseConverter.java
@@ -1,0 +1,42 @@
+package com.computer.nand2tetris.compiler.io;
+
+import com.google.common.base.Optional;
+
+public class CamelCaseConverter {
+
+  public static String convert(String text) {
+    StringBuilder builder = new StringBuilder();
+    convert(text, 0, builder);
+    return builder.toString();
+  }
+
+  private static void convert(String text, int startIndex, StringBuilder builder) {
+    if (startIndex >= text.length()) {
+      return;
+    }
+
+    int delimIndex = findDelimPosition(text, startIndex);
+    builder.append(text, startIndex, delimIndex);
+
+    Optional<Character> upperCasedCharacter =
+        getCamelCaseCharacterForTwoLetterSubstring(text, delimIndex);
+    if (upperCasedCharacter.isPresent()) {
+      builder.append(upperCasedCharacter.get());
+    }
+    convert(text, delimIndex + 2, builder);
+  }
+
+  private static Optional<Character> getCamelCaseCharacterForTwoLetterSubstring(
+      String text,
+      int delimIndex) {
+    int delimFollowerIndex = delimIndex + 1;
+    return delimFollowerIndex < text.length()
+        ? Optional.of(Character.toUpperCase(text.charAt(delimFollowerIndex)))
+        : Optional.absent();
+  }
+
+  private static int findDelimPosition(String text, int startIndex) {
+    int delimIndex = text.indexOf("_", startIndex);
+    return delimIndex >= 0 ? delimIndex : text.length();
+  }
+}

--- a/src/main/java/com/computer/nand2tetris/compiler/io/IOPathsCreator.java
+++ b/src/main/java/com/computer/nand2tetris/compiler/io/IOPathsCreator.java
@@ -9,14 +9,12 @@ import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 public class IOPathsCreator {
 
   private static final String PARSER_OUTPUT_XML_SUFFIX = ".xml";
   private static final String TOKENIZER_OUTPUT_XML_SUFFIX = "T.xml";
-  private static final Pattern JACK_FILE_EXTENSION_PATTERN = Pattern.compile("[.]jack$");
+  private static final String JACK_FILE_EXTENSION = ".jack";
   private static final String OUTPUT_SUBDIR = "parseroutput";
 
   public static ImmutableList<IOPaths> createPaths(String[] args) {
@@ -45,7 +43,7 @@ public class IOPathsCreator {
 
 
   private static boolean hasJackExtension(String path) {
-    return JACK_FILE_EXTENSION_PATTERN.matcher(path).find();
+    return path.endsWith(JACK_FILE_EXTENSION);
   }
 
   private static IOPaths createPathsFromFile(File inputFile) {
@@ -80,11 +78,10 @@ public class IOPathsCreator {
   }
 
   private static String replaceSuffix(Path fileName, String parserOutputXmlSuffix) {
-    StringBuffer sb = new StringBuffer();
-    Matcher matcher = JACK_FILE_EXTENSION_PATTERN.matcher(fileName.toString());
-    Preconditions.checkArgument(matcher.find(), "Expected .jack suffix in %s", fileName);
-    matcher.appendReplacement(sb, parserOutputXmlSuffix);
-    return sb.toString();
+    String stringFileName = fileName.toString();
+    Preconditions.checkArgument(hasJackExtension(stringFileName));
+    return fileName.toString().substring(0, stringFileName.length() - JACK_FILE_EXTENSION.length())
+        + parserOutputXmlSuffix;
   }
 
   private static String extractInputLocation(String[] args) {

--- a/src/main/java/com/computer/nand2tetris/compiler/io/ParsedXmlWriter.java
+++ b/src/main/java/com/computer/nand2tetris/compiler/io/ParsedXmlWriter.java
@@ -12,35 +12,16 @@ public class ParsedXmlWriter extends StackBasedJackElementVisitor {
 
   private final BufferedWriter writer;
   private StringBuilder indentation = new StringBuilder();
+  private final ImmutableSet<String> nonTerminalsToParse;
 
-  ImmutableSet<String> NON_TERMINALS_TO_WRITE =
-      ImmutableSet.of(
-          // program structure
-          "class",
-          "classVarDec",
-          "subroutineDec",
-          "parameterList",
-          "subroutineBody",
-          "varDec",
-          // statements
-          "statements",
-          "whileSatement",
-          "ifStatement",
-          "returnStatement",
-          "letStatement",
-          "doStatement",
-          // expressions
-          "expression",
-          "term",
-          "expressionList");
-
-  public ParsedXmlWriter(BufferedWriter writer) {
+  public ParsedXmlWriter(BufferedWriter writer, ImmutableSet<String> nonTerminalsToParse) {
     this.writer = writer;
+    this.nonTerminalsToParse = nonTerminalsToParse;
   }
 
   @Override
   protected void beginVisitForNonTerminal(String nonTerminalText) {
-    if (NON_TERMINALS_TO_WRITE.contains(nonTerminalText)) {
+    if (nonTerminalsToParse.contains(nonTerminalText)) {
       indentAndWrite(createTag(nonTerminalText));
       increaseIndentation();
       writeNewline();
@@ -49,7 +30,7 @@ public class ParsedXmlWriter extends StackBasedJackElementVisitor {
 
   @Override
   protected void endVisitForNonTerminal(String nonTerminalText) {
-    if (NON_TERMINALS_TO_WRITE.contains(nonTerminalText)) {
+    if (nonTerminalsToParse.contains(nonTerminalText)) {
       decreaseIndentation();
       indentAndWrite(createClosingTag(nonTerminalText));
       writeNewline();

--- a/src/main/java/com/computer/nand2tetris/compiler/io/TokensWriter.java
+++ b/src/main/java/com/computer/nand2tetris/compiler/io/TokensWriter.java
@@ -1,0 +1,16 @@
+package com.computer.nand2tetris.compiler.io;
+
+import com.computer.nand2tetris.compiler.JackToken;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import java.io.BufferedWriter;
+
+public class TokensWriter {
+
+  public void writeTokens(ImmutableList<JackToken> tokens, BufferedWriter writer) {
+    ParsedXmlWriter xmlWriter = new ParsedXmlWriter(writer, ImmutableSet.of("tokens"));
+    xmlWriter.beginNonTerminalVisit("tokens");
+    tokens.stream().forEachOrdered(xmlWriter::visitTerminal);
+    xmlWriter.endNonTerminalVisit();
+  }
+}

--- a/src/main/java/com/computer/nand2tetris/compiler/parser/JackParser.java
+++ b/src/main/java/com/computer/nand2tetris/compiler/parser/JackParser.java
@@ -50,6 +50,27 @@ public class JackParser {
           "&", ","
       );
 
+  public static ImmutableSet<String> NON_TERMINALS_TO_PARSE =
+      ImmutableSet.of(
+          // program structure
+          "class",
+          "classVarDec",
+          "subroutineDec",
+          "parameterList",
+          "subroutineBody",
+          "varDec",
+          // statements
+          "statements",
+          "whileSatement",
+          "ifStatement",
+          "returnStatement",
+          "letStatement",
+          "doStatement",
+          // expressions
+          "expression",
+          "term",
+          "expressionList");
+
   private LookAheadStream<JackToken> tokens;
 
   private JackElementVisitor visitor;

--- a/src/main/java/com/computer/nand2tetris/compiler/parser/JackParser.java
+++ b/src/main/java/com/computer/nand2tetris/compiler/parser/JackParser.java
@@ -47,10 +47,10 @@ public class JackParser {
       ImmutableSet.of(
           "+", "-", "*", "/",
           "<", ">", "=",
-          "&", ","
+          "&", "|"
       );
 
-  public static ImmutableSet<String> NON_TERMINALS_TO_PARSE =
+  public static final ImmutableSet<String> NON_TERMINALS_TO_PARSE =
       ImmutableSet.of(
           // program structure
           "class",
@@ -61,7 +61,7 @@ public class JackParser {
           "varDec",
           // statements
           "statements",
-          "whileSatement",
+          "whileStatement",
           "ifStatement",
           "returnStatement",
           "letStatement",
@@ -178,14 +178,13 @@ public class JackParser {
   }
 
   private void parseSubroutineParameterList() {
-    if (!hasTypeLookaheadToken()) {
-      return;
-    }
     expectAndVisitNonTerminal("parameterList", "subroutine parameter list");
-    parseTypedVarName();
-    while (hasLookaheadText(",")) {
-      match(",");
+    if (hasTypeLookaheadToken()) {
       parseTypedVarName();
+      while (hasLookaheadText(",")) {
+        match(",");
+        parseTypedVarName();
+      }
     }
     endNonTerminalVisit();
   }
@@ -343,15 +342,13 @@ public class JackParser {
   // Expressions
 
   private void parseExpressionList() {
-    if (!hasExpressionLookaheadToken()) {
-      return;
-    }
-
     expectAndVisitNonTerminal("expressionList", "list of expressions");
-    parseExpression();
-    while (hasLookaheadText(",")) {
-      match(",");
+    if (hasExpressionLookaheadToken()) {
       parseExpression();
+      while (hasLookaheadText(",")) {
+        match(",");
+        parseExpression();
+      }
     }
     endNonTerminalVisit();
   }
@@ -409,7 +406,7 @@ public class JackParser {
   }
 
   private void parseTermWithPrecedingUnaryop() {
-    expectAndVisitNonTerminal("term");
+    expectAndVisitNonTerminal("termWithPrecedingUnaryOp", "term preceded by a unary operator");
     matchOneOf(UNARY_OP_TOKENS);
     parseTerm();
     endNonTerminalVisit();


### PR DESCRIPTION
- Dump the tokens in XML format
- token tags must be camel case i.e integerConstant instead of integer_constant
- substitute some token texts with their browsable equivalents. Ex: &gt; instead of >
- remove ',' and add '|' to the list of binary operators.
- output empty expression list and empty parameter list.